### PR TITLE
Add defaults for C++ files

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -86,7 +86,7 @@ function! altr#define_defaults()  "{{{2
   let vim_after_runtime_files = map(copy(vim_runtime_files), '"after/".v:val')
   call altr#define(vim_after_runtime_files + vim_runtime_files)
 
-  call altr#define('%.c', '%.h')  " FIXME: Refine.
+  call altr#define('%.c', '%.cpp', '%.m', '%.h', '%.hpp')  " FIXME: Refine.
 
   call altr#define('%.asax', '%.asax.cs')
   call altr#define('%.ascx', '%.ascx.cs', '%.ascx.designer.cs', '%.ascx.resx') 

--- a/doc/altr.txt
+++ b/doc/altr.txt
@@ -337,9 +337,12 @@ For Vim script: >
 	after/syntax/*/%.vim
 >
 
-For C language: >
+For C, C++ and Objective-C: >
 	%.c
+	%.cpp
+	%.m
 	%.h
+	%.hpp
 <
 
 For ASP.NET: >


### PR DESCRIPTION
Hi Kana!

Thank you for this plugin. For now I'm only using it for C++, but the defaults for Vim script seem quite useful now that I'm Iearning plugin development.

Here is a one line change that adds defaults for one of the most common conventions for C++ that I've seen. In Qt and Boost I've always seen "cpp" for source files, and either "h" or "hpp" for header files, so I think that this will work for almost everyone.

Thanks again.
