### PR TITLE
Fix no rule is matched though rule exists

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -23,7 +23,7 @@
 " }}}
 " Interface  "{{{1
 function! altr#back()  "{{{2
-  call altr#_switch(bufname('%'), 'back', altr#_rule_table())
+  call altr#_switch(expand('%:p'), 'back', altr#_rule_table())
 endfunction
 
 
@@ -99,7 +99,7 @@ endfunction
 
 
 function! altr#forward()  "{{{2
-  call altr#_switch(bufname('%'), 'forward', altr#_rule_table())
+  call altr#_switch(expand('%:p'), 'forward', altr#_rule_table())
 endfunction
 
 


### PR DESCRIPTION
Though rule exists, following message is printed
when current directory and buffer's file path are the same.

"altr: No rule is matched to the current buffer name."

This problem is caused to use bufname("%"). Because bufname() function
return 'relative path'.
So I change to use expand("%:p") instead of bufname("%").
