### PR TITLE
Github changed the raw-data URL.

### DIFF
--- a/doc/altr.txt
+++ b/doc/altr.txt
@@ -73,8 +73,7 @@ Latest version:
 http://github.com/kana/vim-altr
 
 Document in HTML format:
-http://vim-doc.heroku.com/view?https://github.com/kana/vim-altr/blob/master/doc/altr.txt
-
+http://vim-doc.heroku.com/view?https://raw.githubusercontent.com/kana/vim-altr/master/doc/altr.txt
 
 
 


### PR DESCRIPTION
 Fixed the url in the docs so you can view the HTML-version of the documentation on http://vim-doc.heroku.com by just clicking or copy-pasting the url from altr.txt.
