### PR TITLE
Add .cc for C++ and .mm for Objective-C++

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -88,7 +88,7 @@ function! altr#define_defaults()  "{{{2
 
   call altr#define('autoload/%/%.vim', 'doc/%-%.txt', 'plugin/%/%.vim')
 
-  call altr#define('%.c', '%.cpp', '%.m', '%.h', '%.hpp')
+  call altr#define('%.c', '%.cpp', '%.cc', '%.m', '%.mm', '%.h', '%.hpp')
 
   call altr#define('%.asax', '%.asax.cs')
   call altr#define('%.ascx', '%.ascx.cs', '%.ascx.designer.cs', '%.ascx.resx') 

--- a/doc/altr.txt
+++ b/doc/altr.txt
@@ -391,10 +391,12 @@ For opeartor-user and textobj-user based Vim plugins: >
 	plugin/%/%.vim
 >
 
-For C, C++ and Objective-C: >
+For C, C++, Objective-C and Objective-C++:>
 	%.c
 	%.cpp
+	%.cc
 	%.m
+	%.mm
 	%.h
 	%.hpp
 <


### PR DESCRIPTION
Extends defaults for C/C++/Obj-C with .cc for C++ (used for example in Chromium) and .mm for Obj-C++