### PR TITLE
Define altr#define_contain()

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -66,6 +66,42 @@ endfunction
 
 
 
+function! altr#define_contain(...)  "{{{2
+  let file = split(expand("%:r"),'/')[-1]
+  let extension = expand("%:e")
+  let keys = type(a:1) == type([]) ? a:1 : a:000
+  let patterns = []
+  let index = -1
+
+  for rule in keys
+    let index = stridx(file, rule)
+
+    if index != -1
+      let file = substitute(file, rule,'','g')
+      break
+    endif
+  endfor
+
+  if index == -1
+    return
+  endif
+
+  for rule in keys
+    let prefix = ""
+    if index != 0
+      let prefix = file[0:index-1]
+    endif
+
+    let pattern = prefix.rule.file[index:-1].".".extension
+    let patterns = add(patterns, pattern)
+  endfor
+
+  call altr#define(patterns)
+endfunction
+
+
+
+
 function! altr#define_defaults()  "{{{2
   let vim_runtime_files = [
   \   'autoload/%.vim',


### PR DESCRIPTION
Hi!

Added define_contain function.
There are can switching for contain word from file name.

example:
`call altr#define_contain('Model','View','Presenter')`
- TestModel.cs
- TestView.cs
- TestPresenter.cs