### PR TITLE
Add python defaults

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -96,6 +96,8 @@ function! altr#define_defaults()  "{{{2
   call altr#define('%.ascx', '%.ascx.cs', '%.ascx.designer.cs', '%.ascx.resx') 
   call altr#define('%.aspx', '%.aspx.cs', '%.aspx.designer.cs', '%.aspx.resx') 
 
+  call altr#define('%/%.py', '%/test_%.py', '%/tests/test_%.py')
+
   " FIXME: Add more useful defaults.
 endfunction
 


### PR DESCRIPTION
Usually a python package is defined as `/package_name/package_name.py` so I added the double `%` to avoid the greedy algorithm as the docs said.