### PR TITLE
Fix default rule for Go

### DIFF
--- a/autoload/altr.vim
+++ b/autoload/altr.vim
@@ -98,7 +98,7 @@ function! altr#define_defaults()  "{{{2
 
   call altr#define('%/%.py', '%/test_%.py', '%/tests/test_%.py')
 
-  call altr#define('%/%.go', '%/%_test.go')
+  call altr#define('%.go', '%_test.go')
 
   call altr#define('%/%.ml', '%/%.mli', '%/%.mly', '%/%.mll')
 

--- a/doc/altr.txt
+++ b/doc/altr.txt
@@ -458,7 +458,7 @@ For Python: >
 	tests/test_%.py
 <
 
-For Golang: >
+For Go: >
 	%.go
 	%_test.go
 <


### PR DESCRIPTION
The current setting of Go is the following.

> call altr#define('%/%.go', '%/%_test.go')

In the case of Go, source files are often created in the project root directory.
But they doesn't match the pattern of `'%/%.go'` when cwd is the project root.

For that reason, I think it should be the following pattern.

> call altr#define('%.go', '%_test.go')


(This might be related with #20)